### PR TITLE
Add fakes example

### DIFF
--- a/fakes/reader.go
+++ b/fakes/reader.go
@@ -1,0 +1,15 @@
+package fakes
+
+type reader interface {
+	Read() string
+}
+
+type myReader struct{}
+
+func NewMyReader() myReader {
+	return myReader{}
+}
+
+func (r myReader) Read() string {
+	return "Some text"
+}

--- a/fakes/service.go
+++ b/fakes/service.go
@@ -1,0 +1,13 @@
+package fakes
+
+type service struct {
+	rdr reader
+}
+
+func NewService(rdr reader) service {
+	return service{ rdr: rdr}
+}
+
+func (s *service) Serve() string {
+	return s.rdr.Read()
+}

--- a/fakes/service_test.go
+++ b/fakes/service_test.go
@@ -1,0 +1,20 @@
+package fakes_test
+
+import (
+	"ctco-dev/go-testing-frameworks/fakes"
+	"testing"
+)
+
+type fakeReader struct {}
+
+func (f *fakeReader) Read() string {
+	return "foobar"
+}
+
+func TestService_Serve(t *testing.T) {
+	service := fakes.NewService(&fakeReader{})
+	result := service.Serve()
+	if result != "foobar" {
+		t.Error("Expected foobar, but received ", result)
+	}
+}


### PR DESCRIPTION
This is an example on how to write fakes on things that implement some interface, even when the interface is not exported. Test is written it a separate package.